### PR TITLE
Update badge to be clickable link that points to the new project lifecycle documentation

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -1,4 +1,4 @@
-[![badge-labs](https://user-images.githubusercontent.com/327285/230928932-7c75f8ed-e57b-41db-9fb7-a292a13a1e58.svg)](https://community.finos.org/docs/governance/software-projects/project-lifecycle/#labs)
+[![badge-labs](https://user-images.githubusercontent.com/327285/230928932-7c75f8ed-e57b-41db-9fb7-a292a13a1e58.svg)](https://community.finos.org/docs/governance/lifecycle-stages/labs)
 
 # {project name}
 


### PR DESCRIPTION
This PR updates the FINOS badge to be a clickable link pointing to the new project lifecycle documentation.

- Badge is now wrapped in a link to: `https://community.finos.org/docs/governance/lifecycle-stages/labs`

> [!IMPORTANT]
> This PR was generated automatically. We kindly ask you to review it manually, confirm there are no other occurrences of the badge logic in other files, and merge at your earliest convenience. If you have any questions or concerns, please email help@finos.org.